### PR TITLE
Fixed coverage and coveralls reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ node_js:
   - "5"
   - "6"
 
-
+after_success:
+  - npm run coveralls

--- a/Makefile
+++ b/Makefile
@@ -8,16 +8,18 @@ test:
 	  --slow 5000 \
 	  --timeout 10000
 
-test-cov:
-	@NODE_ENV=test ./node_modules/.bin/istanbul cover \
-	./node_modules/mocha/bin/mocha -- -R spec --slow 5000
+# Use 'npm run cover' instead
+#test-cov:
+#	@NODE_ENV=test ./node_modules/.bin/istanbul cover \
+#	./node_modules/mocha/bin/mocha -- -R spec --slow 5000
 
-test-coveralls:
-	echo TRAVIS_JOB_ID $(TRAVIS_JOB_ID)
-	$(MAKE) lint
-	$(MAKE) test
-	@NODE_ENV=test ./node_modules/.bin/istanbul cover \
-	./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec --slow 5000 && \
-	  cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js || true
+# Use 'npm run coveralls' instead
+#test-coveralls:
+#	echo TRAVIS_JOB_ID $(TRAVIS_JOB_ID)
+#	$(MAKE) lint
+#	$(MAKE) test
+#	@NODE_ENV=test ./node_modules/.bin/istanbul cover \
+#	./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec --slow 5000 && \
+#	  cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js || true
 
 .PHONY: test

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "depcheck:unused": "dependency-check ./package.json --unused --no-dev lib/*",
     "test:unit": "mkdir -p reports/ && NODE_ENV=test multi='spec=- xunit=reports/mocha-xunit.xml' istanbul cover _mocha -- -R mocha-multi --timeout 10000 --slow 750 && istanbul check-coverage",
     "test": "npm run depcheck && npm run depcheck:unused && npm run lint && npm run test:unit",
-    "coveralls": "cat ./reports/coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
+    "coveralls": "npm run cover -- --report lcovonly && cat ./reports/coverage/lcov.info | coveralls",
+    "cover": "istanbul cover _mocha"
   },
   "engines": {
     "node": ">= 0.10.x"


### PR DESCRIPTION
Coveralls reporting was not working. This PR slightly changes the way we generate coverage reports, and the way we push the results to coveralls.

- Use `npm cover` to generate coverage locally rather than `make test-cov`.
- `npm coveralls` now executes `npm run cover -- --report lcovonly && cat ./reports/coverage/lcov.info | coveralls`
- `.travis.yml` now runs `npm run coveralls` in the `after_success`

(see also nats-io/node-nats#88 and nats-io/node-nats-streaming#1)