### PR TITLE
Made index.d.ts a valid Typescript module

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,16 @@
 
-declare class Nuid {
+export const VERSION: string;
 
-    /**
-     * Resets the prefix of the global nuid, as well as the
-     * pseudo random sequence number and increment amounts.
-     */
-	next():string;
+/** Returns the next nuid from the global generator.
+ *  
+ * @export
+ * @returns {string}
+ */
+export declare function next(): string;
 
-    /**
-     * Resets the prefix of the global nuid from random bytes, as
-     * well as the pseudo random sequence number and increment amounts.
-     */
-    reset():void;
-}
+/**
+ * Resets the prefix of the global nuid from random bytes, as
+ * well as the pseudo random sequence number and increment amounts.
+ * @export
+ */
+export declare function reset(): void


### PR DESCRIPTION
The Type definition did match the module structure. 

With this new definition, use it as follows

```Typescript

import * as nuid from 'nuid'
console.log('version', nuid.VERSION)
console.log('a new uniqued id', nuid.next())
```